### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ language: php
 
 php:
   - '7.1'
+  - '7.2'
   - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 before_script:
   - travis_retry composer self-update

--- a/tests/ArrayPathTest.php
+++ b/tests/ArrayPathTest.php
@@ -46,7 +46,7 @@ class ArrayPathTest extends TestCase
     {
         (new ArrayPath())->set($this->source, 'key3', 'value3');
 
-        $this->assertTrue(isset($this->source['key3']));
+        $this->assertNotEmpty($this->source['key3']);
         $this->assertSame('value3', $this->source['key3']);
     }
 
@@ -56,7 +56,7 @@ class ArrayPathTest extends TestCase
 
         (new ArrayPath())->set($source, 'key3', 'value3');
 
-        $this->assertTrue(isset($source['key3']));
+        $this->assertNotEmpty($source['key3']);
         $this->assertSame('value3', $source['key3']);
     }
 
@@ -64,7 +64,7 @@ class ArrayPathTest extends TestCase
     {
         (new ArrayPath())->set($this->source, 'key1.key13.key131', 'value131');
 
-        $this->assertTrue(isset($this->source['key1']['key13']['key131']));
+        $this->assertNotEmpty($this->source['key1']['key13']['key131']);
         $this->assertSame('value131', $this->source['key1']['key13']['key131']);
     }
 


### PR DESCRIPTION
# Changed log
- Using the `assertNotEmpty` is better than using `isset` function with `assertTrue`.
- Add the `php-7.2` test and let the `php-nightly` allow to be failed because nobody can guarantee that `php-nightly` test will be successful every time.